### PR TITLE
Version update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,7 +125,7 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "ascii_to_png"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "clap",
  "image",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ascii_to_png"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
Update version of `ascii_to_png` to `0.3.0`, as the program can now generate its own ASCII before converting to PNG.