### PR TITLE
Naming change.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,22 +137,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
-name = "ascii_to_png"
-version = "0.4.1"
-dependencies = [
- "ab_glyph",
- "clap",
- "image",
- "imageproc",
- "num_cpus",
- "rascii_art",
- "rayon",
- "regex",
- "threadpool",
- "unicode-segmentation",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -258,9 +242,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.5.29"
+version = "4.5.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acebd8ad879283633b343856142139f2da2317c96b05b4dd6181c61e2480184"
+checksum = "92b7b18d71fad5313a1e320fa9897994228ce274b60faa4d694fe0ea89cd9e6d"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -268,9 +252,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.29"
+version = "4.5.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ba32cbda51c7e1dfd49acc1457ba1a7dec5b64fe360e828acb13ca8dc9c2f9"
+checksum = "a35db2071778a7344791a4fb4f95308b5673d219dee3ae348b86642574ecc90c"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1041,6 +1025,22 @@ name = "rgb"
 version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57397d16646700483b67d2dd6511d79318f9d057fdbd21a4066aeac8b41d310a"
+
+[[package]]
+name = "rustii"
+version = "0.4.1"
+dependencies = [
+ "ab_glyph",
+ "clap",
+ "image",
+ "imageproc",
+ "num_cpus",
+ "rascii_art",
+ "rayon",
+ "regex",
+ "threadpool",
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "safe_arch"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1028,7 +1028,7 @@ checksum = "57397d16646700483b67d2dd6511d79318f9d057fdbd21a4066aeac8b41d310a"
 
 [[package]]
 name = "rustii"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "ab_glyph",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-name = "ascii_to_png"
+name = "rustii"
 version = "0.4.1"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 ab_glyph = "0.2.29"
-clap = "4.5.29"
+clap = "4.5.30"
 image = "0.25.5"
 imageproc = "0.25.0"
 num_cpus = "1.16.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustii"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2024"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Options:
 ```
 
 ```sh
-cargo run --release my_image.png my_ascii.png
+cargo run --release -- my_image.png my_ascii.png
 ```
 
 ## Example Output

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Options:
 ```
 
 ```sh
-cargo run -- my_image.png my_ascii.png
+cargo run --release my_image.png my_ascii.png
 ```
 
 ## Example Output

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ascii_to_png
+# rustii
 
 This is a CPU-only image rendering program that renders colored ANSI-encoded ASCII art and saves them in the
 PNG format.
@@ -10,7 +10,7 @@ which this program can handle for you).
 ## Usage
 
 ```text
-Usage: ascii_to_png [OPTIONS] <INPUT_FILENAME> <OUTPUT_FILENAME> [FINAL_IMAGE_INDEX]
+Usage: rustii [OPTIONS] <INPUT_FILENAME> <OUTPUT_FILENAME> [FINAL_IMAGE_INDEX]
 
 Arguments:
   <INPUT_FILENAME>
@@ -49,6 +49,11 @@ Options:
           Sets a black background behind the image.
           
           No background by default.
+
+  -C, --charset <CHARSET>
+          Characters used to render the image, from transparent to opaque. Built-in charsets: block, emoji, default, russian, slight, minimal
+          
+          [default: minimal]
 
   -h, --help
           Print help (see a summary with '-h')

--- a/README.md
+++ b/README.md
@@ -66,6 +66,13 @@ Options:
 cargo run --release -- my_image.png my_ascii.png
 ```
 
+### Example Usage With Args
+
+```sh
+# converting an image and rendering it to a width of 150, using the block charset
+cargo run --release -- --charset block --width 150 my_image.png my_ascii.png
+```
+
 ## Example Output
 
 Original Image:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # rustii
 
-This is a CPU-only image rendering program that renders colored ANSI-encoded ASCII art and saves them in the
+This is a CPU-only image rendering program that renders colored ANSI-encoded ASCII art and saves it in the
 PNG format.
 
 This program is multithreaded to make it faster, but it is very CPU-intensive due to not utilizing the GPU.


### PR DESCRIPTION
Updates name of program.
- Update to 2024 edition of Rust.
- Update `clap` to `4.5.30`.
- Update documentation.