### PR TITLE
Add gif support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "ab_glyph"
-version = "0.2.29"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3672c180e71eeaaac3a541fbbc5f5ad4def8b747c595ad30d674e43049f7b0"
+checksum = "01c0457472c38ea5bd1c3b5ada5e368271cb550be7a4ca4a0b4634e9913f6cc2"
 dependencies = [
  "ab_glyph_rasterizer",
  "owned_ttf_parser",
@@ -158,9 +158,9 @@ dependencies = [
 
 [[package]]
 name = "avif-serialize"
-version = "0.8.2"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e335041290c43101ca215eed6f43ec437eb5a42125573f600fc3fa42b9bddd62"
+checksum = "47c8fbc0f831f4519fe8b810b6a7a91410ec83031b8233f730a0480029f6a23f"
 dependencies = [
  "arrayvec",
 ]
@@ -173,9 +173,9 @@ checksum = "dc827186963e592360843fb5ba4b973e145841266c1357f7180c43526f2e5b61"
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
+version = "2.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
 
 [[package]]
 name = "bitstream-io"
@@ -242,9 +242,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.5.35"
+version = "4.5.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8aa86934b44c19c50f87cc2790e19f54f7a67aedb64101c2e1a2e5ecfb73944"
+checksum = "e2134bb3ea021b78629caa971416385309e0131b351b25e01dc16fb54e1b5fae"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -252,9 +252,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.35"
+version = "4.5.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2414dbb2dd0695280da6ea9261e327479e9d37b0630f6b53ba2a11c60c679fd9"
+checksum = "c2ba64afa3c0a6df7fa517765e31314e983f51dda798ffba27b988194fb65dc9"
 dependencies = [
  "anstream",
  "anstyle",
@@ -264,9 +264,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.32"
+version = "4.5.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
+checksum = "bbfd7eae0b0f1a6e63d4b13c9c478de77c2eb546fba158ad50b4203dc24b9f9c"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -339,6 +339,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
+name = "env_filter"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "jiff",
+ "log",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -357,6 +380,26 @@ dependencies = [
  "rayon-core",
  "smallvec",
  "zune-inflate",
+]
+
+[[package]]
+name = "fax"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05de7d48f37cd6730705cbca900770cab77a89f413d23e100ad7fad7795a0ab"
+dependencies = [
+ "fax_derive",
+]
+
+[[package]]
+name = "fax_derive"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0aca10fb742cb43f9e7bb8467c91aa9bcb8e3ffbc6a6f7389bb93ffc920577d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -425,15 +468,15 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.9"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "image"
-version = "0.25.6"
+version = "0.25.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db35664ce6b9810857a38a906215e75a9c879f0696556a39f59c62829710251a"
+checksum = "529feb3e6769d234375c4cf1ee2ce713682b8e76538cb13f9fc23e1400a591e7"
 dependencies = [
  "bytemuck",
  "byteorder-lite",
@@ -441,6 +484,7 @@ dependencies = [
  "exr",
  "gif",
  "image-webp",
+ "moxcms",
  "num-traits",
  "png",
  "qoi",
@@ -523,6 +567,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "jiff"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be1f93b8b1eb69c77f24bbb0afdf66f54b632ee39af40ca21c4365a1d7347e49"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -530,12 +598,6 @@ checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "jpeg-decoder"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5d4a7da358eff58addd2877a45865158f0d78c911d43a5784ceb7bbf52833b0"
 
 [[package]]
 name = "js-sys"
@@ -577,9 +639,9 @@ checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
 name = "loop9"
@@ -630,6 +692,16 @@ checksum = "4ffbe83022cedc1d264172192511ae958937694cd57ce297164951b8b3568394"
 dependencies = [
  "adler2",
  "simd-adler32",
+]
+
+[[package]]
+name = "moxcms"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c588e11a3082784af229e23e8e4ecf5bcc6fbe4f69101e0421ce8d79da7f0b40"
+dependencies = [
+ "num-traits",
+ "pxfm",
 ]
 
 [[package]]
@@ -756,9 +828,9 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
  "hermit-abi",
  "libc",
@@ -793,9 +865,9 @@ checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
 name = "png"
-version = "0.17.16"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526"
+checksum = "97baced388464909d42d89643fe4361939af9b7ce7a31ee32a168f832a70f2a0"
 dependencies = [
  "bitflags",
  "crc32fast",
@@ -806,17 +878,33 @@ dependencies = [
 
 [[package]]
 name = "pngii"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "ab_glyph",
  "clap",
+ "env_logger",
  "image",
  "imageproc",
+ "log",
  "num_cpus",
  "rascii_art",
  "rayon",
  "regex",
- "threadpool",
+]
+
+[[package]]
+name = "portable-atomic"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+dependencies = [
+ "portable-atomic",
 ]
 
 [[package]]
@@ -830,9 +918,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.92"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
+checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
 dependencies = [
  "unicode-ident",
 ]
@@ -854,6 +942,15 @@ checksum = "a65f2e60fbf1063868558d69c6beacf412dc755f9fc020f514b7955fc914fe30"
 dependencies = [
  "quote",
  "syn",
+]
+
+[[package]]
+name = "pxfm"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3cbdf373972bf78df4d3b518d07003938e2c7d1fb5891e55f9cb6df57009d84"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -967,9 +1064,9 @@ dependencies = [
 
 [[package]]
 name = "ravif"
-version = "0.11.11"
+version = "0.11.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2413fd96bd0ea5cdeeb37eaf446a22e6ed7b981d792828721e74ded1980a45c6"
+checksum = "5825c26fddd16ab9f515930d49028a630efec172e903483c94796cfe31893e6b"
 dependencies = [
  "avif-serialize",
  "imgref",
@@ -988,9 +1085,9 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
 dependencies = [
  "either",
  "rayon-core",
@@ -998,9 +1095,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.12.1"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
@@ -1008,9 +1105,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.1"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+checksum = "4a52d8d02cacdb176ef4678de6c052efb4b3da14b78e4db683a4252762be5433"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1020,9 +1117,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.9"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+checksum = "722166aa0d7438abbaa4d5cc2c649dac844e8c56d82fb3d33e9c34b5cd268fc6"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1127,9 +1224,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.95"
+version = "2.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46f71c0377baf4ef1cc3e3402ded576dccc315800fbc62dfc7fe04b009773b4a"
+checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1176,23 +1273,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "threadpool"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
-dependencies = [
- "num_cpus",
-]
-
-[[package]]
 name = "tiff"
-version = "0.9.1"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba1310fcea54c6a9a4fd1aad794ecc02c31682f6bfbecdf460bf19533eed1e3e"
+checksum = "af9605de7fee8d9551863fd692cce7637f548dbd9db9180fcc07ccc6d26c336f"
 dependencies = [
+ "fax",
  "flate2",
- "jpeg-decoder",
+ "half",
+ "quick-error",
  "weezl",
+ "zune-jpeg",
 ]
 
 [[package]]
@@ -1338,9 +1429,9 @@ checksum = "943aab3fdaaa029a6e0271b35ea10b72b943135afe9bffca82384098ad0e06a6"
 
 [[package]]
 name = "weezl"
-version = "0.1.8"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53a85b86a771b1c87058196170769dd264f66c0782acf1ae6cc51bfd64b39082"
+checksum = "a751b3277700db47d3e574514de2eced5e54dc8a5436a3bf7a0b248b2cee16f3"
 
 [[package]]
 name = "wide"
@@ -1494,9 +1585,9 @@ dependencies = [
 
 [[package]]
 name = "zune-jpeg"
-version = "0.4.14"
+version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99a5bab8d7dedf81405c4bb1f2b83ea057643d9cb28778cea9eecddeedd2e028"
+checksum = "29ce2c8a9384ad323cf564b67da86e21d3cfdff87908bc1223ed5c99bc792713"
 dependencies = [
  "zune-core",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,15 +1,16 @@
 [package]
 name = "pngii"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2024"
 
 [dependencies]
-ab_glyph = "0.2.29"
-clap = "4.5.35"
-image = { version = "0.25.6", features = ["gif"]}
+ab_glyph = "0.2.32"
+clap = "4.5.48"
+env_logger = "0.11.8"
+image = { version = "0.25.8", features = ["gif"]}
 imageproc = "0.25.0"
-num_cpus = "1.16.0"
+log = "0.4.28"
+num_cpus = "1.17.0"
 rascii_art = { version = "0.4.5", path = "RASCII" }
-rayon = "1.10.0"
-regex = "1.11.1"
-threadpool = "1.8.1"
+rayon = "1.11.0"
+regex = "1.12.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2024"
 [dependencies]
 ab_glyph = "0.2.29"
 clap = "4.5.35"
-image = "0.25.6"
+image = { version = "0.25.6", features = ["gif"]}
 imageproc = "0.25.0"
 num_cpus = "1.16.0"
 rascii_art = { version = "0.4.5", path = "RASCII" }

--- a/TODO.md
+++ b/TODO.md
@@ -1,3 +1,5 @@
 # TODO
 
 - Add brightness setting (0-100) to allow brightening dark images
+- Instead of using 2d vectors throughout the program, flatten them into single vectors
+- Speed up GIF encoding (seems to take up the most time when converting GIFs)

--- a/TODO.md
+++ b/TODO.md
@@ -3,3 +3,4 @@
 - Add brightness setting (0-100) to allow brightening dark images
 - Instead of using 2d vectors throughout the program, flatten them into single vectors
 - Speed up GIF encoding (seems to take up the most time when converting GIFs)
+- More robust error handling. Make it so we can avoid as many (or all panics)

--- a/src/image_helper/ascii_image_options.rs
+++ b/src/image_helper/ascii_image_options.rs
@@ -1,7 +1,7 @@
 use crate::image_helper::render_char_to_png::DEFAULT_CHAR_FONT_SIZE;
 
 /// Options for creating the output ASCII PNG.
-pub struct AsciiImageOptions {
+pub struct PngiiOptions {
     /// The font size of the output image.
     font_size: Option<u32>,
 
@@ -11,7 +11,7 @@ pub struct AsciiImageOptions {
     pub background: bool,
 }
 
-impl AsciiImageOptions {
+impl PngiiOptions {
     /// Creates a new image options object.
     pub fn new(font_size: Option<u32>, background: bool) -> Self {
         Self {

--- a/src/image_helper/ascii_image_options.rs
+++ b/src/image_helper/ascii_image_options.rs
@@ -1,6 +1,7 @@
 use crate::image_helper::render_char_to_png::DEFAULT_CHAR_FONT_SIZE;
 
 /// Options for creating the output ASCII PNG.
+#[derive(Debug)]
 pub struct PngiiOptions {
     /// The font size of the output image.
     font_size: Option<u32>,

--- a/src/image_helper/image_converter.rs
+++ b/src/image_helper/image_converter.rs
@@ -1,19 +1,47 @@
-use std::{fs::File, io::BufReader};
+use std::{fs::File, io::BufReader, sync::Mutex};
 
 use crate::{
-    AsciiImageOptions,
+    PngiiOptions,
     image_helper::{image_data::ImageData, render_char_to_png::str_to_png},
 };
 
 use super::render_char_to_png::{ColoredStr, str_to_transparent_png};
 use ab_glyph::FontRef;
-use image::{AnimationDecoder, DynamicImage, codecs::gif::GifDecoder, open};
+use image::{AnimationDecoder, Delay, DynamicImage, Frame, codecs::gif::GifDecoder, open};
 use rascii_art::{RenderOptions, render_image_to};
+use rayon::iter::{IntoParallelIterator, IntoParallelRefIterator, ParallelIterator};
 use regex::Regex;
 
 // read bytes for the font
 const FONT_BYTES: &[u8] = include_bytes!("../../fonts/UbuntuMono.ttf");
 
+/// Holds the metadata for a frame that has been deconstructed.
+///
+/// * `image`: The image for this frame.
+/// * `left`: The left value for this frame.
+/// * `top`: The top value for this frame.
+/// * `delay`: The delay for this frame.
+/// * `idx`: The index of this frame. Saved for handling out of order frames due to multithreading.
+pub struct FrameMetadata {
+    pub left: u32,
+    pub top: u32,
+    pub delay: Delay,
+    pub idx: usize,
+}
+
+impl FrameMetadata {
+    /// Creates a new FrameMetadata.
+    fn new(left: u32, top: u32, delay: Delay, idx: usize) -> Self {
+        Self {
+            left,
+            top,
+            delay,
+            idx,
+        }
+    }
+}
+
+// TODO: document
 /// Reads a GIF into a `Vec<DynamicImage>` for use with converting to ASCII.
 ///
 /// # Params
@@ -21,18 +49,30 @@ const FONT_BYTES: &[u8] = include_bytes!("../../fonts/UbuntuMono.ttf");
 ///
 /// # Returns
 /// `Err()` upon error reading the GIF, `Ok()` otherwise.
-fn read_gif(input_file_name: &str) -> Result<Vec<DynamicImage>, std::io::Error> {
+fn read_gif(input_file_name: &str) -> Result<Vec<(DynamicImage, FrameMetadata)>, std::io::Error> {
     let file_in = BufReader::new(File::open(input_file_name)?);
     let decoder =
         GifDecoder::new(file_in).expect(format!("Could not read gif {}", input_file_name).as_str());
 
+    let mut cur_idx = 0 as usize;
     // decode all of the frames of the gif and then convert each frame into a DynamicImage
     let frames = decoder
         .into_frames()
         .collect_frames()
         .expect(format!("Could not decode gif {}", input_file_name).as_str())
         .into_iter()
-        .map(|value| value.into_buffer().into())
+        .map(|value| {
+            let idx = cur_idx;
+            let left = value.left();
+            let top = value.top();
+            let delay = value.delay();
+            cur_idx += 1; // increment the current index
+            (
+                // we split this from the frame metadata because we will not want the original image once we have converted it to ASCII
+                value.into_buffer().into(),
+                FrameMetadata::new(left, top, delay, idx),
+            )
+        })
         .collect();
 
     Ok(frames)
@@ -57,24 +97,33 @@ fn read_image_as_ascii(input_file_name: &str, rascii_options: &RenderOptions) ->
     ascii_text
 }
 
-/// Reads and converts an image to ASCII and renders it into image.
-///
-/// # Params
-/// * `input_file_name`: The input file name of the image to convert.
-/// * `rascii_options`: The `RASCII` image options.
-/// * `ascii_image_options`: The `PNGII` image options.
-///
-/// # Returns
-/// * `Vec<Vec<ImageData>>`: A 2d `Vec` of images, containing each rendered character from the
-/// image.
-pub fn parse_ascii_to_2d_image_vec(
+/// Reads a gif as a list of ASCII strings
+/// TODO: documentation
+fn read_gif_as_ascii(
     input_file_name: &str,
     rascii_options: &RenderOptions,
-    ascii_image_options: &AsciiImageOptions,
-) -> Vec<Vec<ImageData>> {
+) -> Vec<(String, FrameMetadata)> {
+    // render the ascii text with RASCII
+    let gif_images = read_gif(input_file_name)
+        .expect(format!("Could not read gif {}", input_file_name).as_str());
+
+    // PERF: check rayon performance vs. threadpool for gif
+    // TODO: this data can probably be out of order due to multithreading, we might need to sort on
+    // `idx`
+    gif_images
+        .into_par_iter()
+        .map(|(image, deconstructed_frame)| {
+            let mut ascii_text = String::new();
+            render_image_to(&image, &mut ascii_text, rascii_options);
+            (ascii_text, deconstructed_frame)
+        })
+        .collect()
+}
+
+// TODO: doc
+fn parse_ascii_generic(pngii_options: &PngiiOptions, ascii_text: String) -> Vec<Vec<ImageData>> {
     // set up font for rendering
     let font = FontRef::try_from_slice(FONT_BYTES).expect("Could not read input font");
-    let ascii_text = read_image_as_ascii(input_file_name, rascii_options);
 
     // contains lines of images
     // starting at 0 is the top, first line of the vector
@@ -92,11 +141,13 @@ pub fn parse_ascii_to_2d_image_vec(
         let pattern = r"\[38;2;([0-9]+);([0-9]+);([0-9]+)m(.)";
         pattern_string += pattern;
 
+        // TODO: if multiple threads are using this same regex object, maybe we could make it a
+        // static global or compile it early so we can reuse it? Maybe as a "parser" object?
         let re = Regex::new(&pattern_string)
             .expect(format!("Error creating regex pattern ({})", pattern).as_str());
 
         // create the image for this character
-        for (full_str, [r, g, b, the_str]) in re.captures_iter(&line).map(|c| c.extract()) {
+        for (full_str, [r, g, b, the_str]) in re.captures_iter(line).map(|c| c.extract()) {
             let red = r.parse::<u8>().expect(
                 format!(
                     "Error parsing red from string: ({}), full string: ({}). Improper encoding?",
@@ -122,7 +173,7 @@ pub fn parse_ascii_to_2d_image_vec(
             let generated_png = {
                 if the_str.trim().is_empty() {
                     // create a transparent png for a space
-                    str_to_transparent_png(ascii_image_options)
+                    str_to_transparent_png(pngii_options)
                 } else {
                     // render the actual text if it's not empty
                     let colored = ColoredStr {
@@ -132,7 +183,7 @@ pub fn parse_ascii_to_2d_image_vec(
                         string: String::from(the_str),
                     };
 
-                    str_to_png(colored, &font, ascii_image_options)
+                    str_to_png(colored, &font, pngii_options)
                         .expect(format!("Could not convert str ({}) to PNG", the_str).as_str())
                 }
             };
@@ -144,4 +195,46 @@ pub fn parse_ascii_to_2d_image_vec(
     }
 
     image_2d_vec
+}
+
+/// Reads and converts an image to ASCII and renders it into image.
+///
+/// # Params
+/// * `input_file_name`: The input file name of the image to convert.
+/// * `rascii_options`: The `RASCII` image options.
+/// * `pngii_options`: The `PNGII` image options.
+///
+/// # Returns
+/// * `Vec<Vec<ImageData>>`: A 2d `Vec` of images, containing each rendered character from the
+/// image.
+pub fn parse_ascii_to_2d_image_vec(
+    input_file_name: &str,
+    rascii_options: &RenderOptions,
+    pngii_options: &PngiiOptions,
+) -> Vec<Vec<ImageData>> {
+    let ascii_text = read_image_as_ascii(input_file_name, rascii_options);
+    parse_ascii_generic(pngii_options, ascii_text)
+}
+
+// TODO: doc
+pub fn parse_ascii_to_gif_vec(
+    input_file_name: &str,
+    rascii_options: &RenderOptions,
+    pngii_options: &PngiiOptions,
+) -> Vec<(Vec<Vec<ImageData>>, FrameMetadata)> {
+    let ascii_text = read_gif_as_ascii(input_file_name, rascii_options);
+
+    // TODO: this can probably cause things to be collected out of order so handle that (probably
+    // want to keep an index along with each frame so we can put them back into order at the end)
+
+    // create image data for each frame and keep the frame metadata so we can use it again later
+    ascii_text
+        .into_par_iter()
+        .map(|(image_text, deconstructed_frame)| {
+            (
+                parse_ascii_generic(pngii_options, image_text),
+                deconstructed_frame,
+            )
+        })
+        .collect()
 }

--- a/src/image_helper/image_converter.rs
+++ b/src/image_helper/image_converter.rs
@@ -12,20 +12,20 @@ use rascii_art::{RenderOptions, render_image_to};
 use rayon::iter::{IntoParallelIterator, IntoParallelRefIterator, ParallelIterator};
 use regex::Regex;
 
+// TODO: Read this font at runtime instead and allow the user to choose
+
 // read bytes for the font
 const FONT_BYTES: &[u8] = include_bytes!("../../fonts/UbuntuMono.ttf");
 
 /// Holds the metadata for a frame that has been deconstructed.
-///
-/// * `image`: The image for this frame.
-/// * `left`: The left value for this frame.
-/// * `top`: The top value for this frame.
-/// * `delay`: The delay for this frame.
-/// * `idx`: The index of this frame. Saved for handling out of order frames due to multithreading.
 pub struct FrameMetadata {
+    /// The left value for this frame.
     pub left: u32,
+    /// The top value for this frame.
     pub top: u32,
+    /// The delay for this frame.
     pub delay: Delay,
+    /// The index of this frame. Saved for handling out of order frames due to multithreading.
     pub idx: usize,
 }
 
@@ -61,15 +61,15 @@ fn read_gif(input_file_name: &str) -> Result<Vec<(DynamicImage, FrameMetadata)>,
         .collect_frames()
         .expect(format!("Could not decode gif {}", input_file_name).as_str())
         .into_iter()
-        .map(|value| {
+        .map(|frame| {
             let idx = cur_idx;
-            let left = value.left();
-            let top = value.top();
-            let delay = value.delay();
+            let left = frame.left();
+            let top = frame.top();
+            let delay = frame.delay();
             cur_idx += 1; // increment the current index
             (
                 // we split this from the frame metadata because we will not want the original image once we have converted it to ASCII
-                value.into_buffer().into(),
+                frame.into_buffer().into(),
                 FrameMetadata::new(left, top, delay, idx),
             )
         })

--- a/src/image_helper/image_data.rs
+++ b/src/image_helper/image_data.rs
@@ -23,3 +23,17 @@ impl Deref for ImageData {
         &self.0
     }
 }
+
+// Simple conversions to make it possible to convert to and from an ImageData
+// and its inner held type.
+impl From<ImageBuffer<image::Rgba<u8>, Vec<u8>>> for ImageData {
+    fn from(value: ImageBuffer<image::Rgba<u8>, Vec<u8>>) -> Self {
+        Self(value)
+    }
+}
+
+impl Into<ImageBuffer<image::Rgba<u8>, Vec<u8>>> for ImageData {
+    fn into(self) -> ImageBuffer<image::Rgba<u8>, Vec<u8>> {
+        self.0
+    }
+}

--- a/src/image_helper/image_writer.rs
+++ b/src/image_helper/image_writer.rs
@@ -1,5 +1,5 @@
 use crate::{
-    AsciiImageOptions,
+    PngiiOptions,
     image_helper::{image_data::ImageData, render_char_to_png::calculate_char_dimensions},
 };
 use rayon::prelude::*;
@@ -28,15 +28,12 @@ impl AsciiImageWriter {
     /// # Returns
     /// - An `Option` containing `Some` `AsciiImageWriter` upon success, or a
     /// `None` upon failure.
-    pub fn from_2d_vec(
-        parts: Vec<Vec<ImageData>>,
-        ascii_image_options: &AsciiImageOptions,
-    ) -> Option<Self> {
+    pub fn from_2d_vec(parts: Vec<Vec<ImageData>>, pngii_options: &PngiiOptions) -> Option<Self> {
         if parts.is_empty() || parts[0].is_empty() {
             return None; // no image to build
         }
 
-        let font_size = ascii_image_options.get_font_size();
+        let font_size = pngii_options.get_font_size();
 
         let (mut height, mut width) = (0, 0);
         // find out the new canvas size

--- a/src/image_types.rs
+++ b/src/image_types.rs
@@ -1,0 +1,4 @@
+pub enum OutputImageType {
+    Png,
+    Gif,
+}

--- a/src/image_types.rs
+++ b/src/image_types.rs
@@ -10,7 +10,7 @@ const IMG_TYPE_PNG: &'static str = ".png";
 const IMG_TYPE_GIF: &'static str = ".gif";
 
 /// All image types stored in an array, for iterating through all image types.
-pub const IMG_TYPES_ARRAY: [&'static str; 2] = [IMG_TYPE_PNG, IMG_TYPE_GIF];
+pub const IMG_TYPES_ARRAY: &[&'static str] = &[IMG_TYPE_PNG, IMG_TYPE_GIF];
 
 impl OutputImageType {
     /// Converts a string slice to an `OutputImageType`.
@@ -51,7 +51,8 @@ impl OutputImageType {
 
 /// Holds whether the program should convert a batch of inputs or just a single.
 #[derive(PartialEq, Eq)]
-pub enum OutputSize {
+pub enum ImageBatchType {
     Single,
-    Batch,
+    /// Contains the final index for this batch
+    BatchWithFinalIdx(u32),
 }

--- a/src/image_types.rs
+++ b/src/image_types.rs
@@ -1,4 +1,9 @@
+/// Holds the image types that this program can output.
+/// Each value holds an index into the `IMAGE_STR_TYPES` array.
 pub enum OutputImageType {
-    Png,
-    Gif,
+    Png = 0,
+    Gif = 1,
 }
+
+/// Use the value of `OutputImageType` as the index to this array
+pub const IMAGE_STR_TYPES: [&'static str; 2] = [".png", ".gif"];

--- a/src/image_types.rs
+++ b/src/image_types.rs
@@ -50,7 +50,6 @@ impl OutputImageType {
 }
 
 /// Holds whether the program should convert a batch of inputs or just a single.
-#[derive(PartialEq, Eq)]
 pub enum ImageBatchType {
     Single,
     /// Contains the final index for this batch

--- a/src/image_types.rs
+++ b/src/image_types.rs
@@ -1,9 +1,57 @@
-/// Holds the image types that this program can output.
+/// Holds the image types that PNGII can output.
 /// Each value holds an index into the `IMAGE_STR_TYPES` array.
 pub enum OutputImageType {
-    Png = 0,
-    Gif = 1,
+    Png,
+    Gif,
 }
 
-/// Use the value of `OutputImageType` as the index to this array
-pub const IMAGE_STR_TYPES: [&'static str; 2] = [".png", ".gif"];
+// image type string defines
+const IMG_TYPE_PNG: &'static str = ".png";
+const IMG_TYPE_GIF: &'static str = ".gif";
+
+/// All image types stored in an array, for iterating through all image types.
+pub const IMG_TYPES_ARRAY: [&'static str; 2] = [IMG_TYPE_PNG, IMG_TYPE_GIF];
+
+impl OutputImageType {
+    /// Converts a string slice to an `OutputImageType`.
+    ///
+    /// * `output_image_type_str`:
+    fn from_str(output_image_type_str: &str) -> Option<Self> {
+        match output_image_type_str {
+            IMG_TYPE_PNG => Some(OutputImageType::Png),
+            IMG_TYPE_GIF => Some(OutputImageType::Gif),
+            _ => None,
+        }
+    }
+
+    /// Converts this file name to an `OutputImageType`.
+    ///
+    /// * `file_name`: The file name to check the file extension of.
+    pub fn from_file_name(file_name: &str) -> Option<Self> {
+        // find where the file extension starts (last "." in the string)
+        let file_extension_start_idx = file_name.rfind(".");
+        match file_extension_start_idx {
+            Some(file_extension_start_idx) => {
+                // match the string, starting from the last "."
+                // see if this file extension matches any of the file extension strings we have
+                Self::from_str(&file_name[file_extension_start_idx..])
+            }
+            None => None,
+        }
+    }
+
+    /// Converts to this type's file extension.
+    pub fn as_file_extension(&self) -> &'static str {
+        match *self {
+            OutputImageType::Png => IMG_TYPE_PNG,
+            OutputImageType::Gif => IMG_TYPE_GIF,
+        }
+    }
+}
+
+/// Holds whether the program should convert a batch of inputs or just a single.
+#[derive(PartialEq, Eq)]
+pub enum OutputSize {
+    Single,
+    Batch,
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,7 +116,19 @@ pub fn convert_to_ascii_gif(
         }
     };
     let file_writer = BufWriter::new(out_file);
+
     let mut gif_encoder = GifEncoder::new(file_writer);
+
+    // TODO: allow user to choose number of repeats?
+    let err = gif_encoder.set_repeat(image::codecs::gif::Repeat::Infinite);
+    match err {
+        Err(err) => {
+            // give a warning if the repeat couldn't be set properly
+            log::warn!("Could not set repeat ({err})");
+        }
+        Ok(_) => {}
+    }
+
     // encode the frames
     match gif_encoder.encode_frames(frames) {
         Err(err) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,11 +73,6 @@ pub fn convert_to_ascii_gif(
     let raw_frames =
         read_as_deconstructed_rendered_gif_vec(input_file_name, rascii_options, pngii_options);
 
-    // FIXME: the order of these images can be determined by their index, so we might need to
-    // handle that. Probably need to sort the image_writers vec
-
-    // FIXME: for some reason, GIFs will freeze right before the end??? Why is this happening?
-
     // create an image writer for each frame
     let image_writers: Vec<(Option<AsciiImageWriter>, FrameMetadata)> = raw_frames
         .into_par_iter()
@@ -89,7 +84,6 @@ pub fn convert_to_ascii_gif(
         })
         .collect();
 
-    // FIXME: now we need to bring the gif together frame-by-frame. Check that this is accurate.
     let frames: Vec<Frame> = image_writers
         .into_par_iter()
         .map(|(image_writer, frame_metadata)| match image_writer {
@@ -128,6 +122,9 @@ pub fn convert_to_ascii_gif(
         }
         Ok(_) => {}
     }
+
+    // FUTURE: the longest part of the GIF creation process is encoding...is there any way to speed
+    // it up?
 
     // encode the frames
     match gif_encoder.encode_frames(frames) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,6 +76,8 @@ pub fn convert_to_ascii_gif(
     // FIXME: the order of these images can be determined by their index, so we might need to
     // handle that. Probably need to sort the image_writers vec
 
+    // FIXME: for some reason, GIFs will freeze right before the end??? Why is this happening?
+
     // create an image writer for each frame
     let image_writers: Vec<(Option<AsciiImageWriter>, FrameMetadata)> = raw_frames
         .into_par_iter()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![allow(non_snake_case)]
 pub mod image_helper;
+pub mod image_types;
 use image_helper::{
     ascii_image_options::AsciiImageOptions, image_converter::parse_ascii_to_2d_image_vec,
     image_writer::AsciiImageWriter,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,33 +1,39 @@
 #![allow(non_snake_case)]
 pub mod image_helper;
 pub mod image_types;
+use std::{fs::File, io::BufWriter};
+
+use image::{Frame, codecs::gif::GifEncoder};
 use image_helper::{
-    ascii_image_options::AsciiImageOptions, image_converter::parse_ascii_to_2d_image_vec,
+    ascii_image_options::PngiiOptions, image_converter::parse_ascii_to_2d_image_vec,
     image_writer::AsciiImageWriter,
 };
 use rascii_art::RenderOptions;
+use rayon::iter::{IntoParallelIterator, ParallelIterator};
+
+use crate::image_helper::image_converter::{FrameMetadata, parse_ascii_to_gif_vec};
 
 /// Converts an image (such as a PNG or JPEG) into an ASCII PNG.
-/// It does this by first converting the iamge into colored ASCII art,
+/// It does this by first converting the image into colored ASCII art,
 /// then renders the ASCII art as an image.
 ///
 /// # Params
 /// - `input_file_name` - The input file name.
 /// - `output_file_name` - The output file name.
 /// - `rascii_options` - The `RASCII` render options.
-/// - `ascii_image_options` - The `PNGII` render options
+/// - `pngii_options` - The `PNGII` render options
 ///
 /// # Returns
 /// - `Err(())` upon error, `Ok(())` otherwise.
-pub fn convert_image_to_ascii_png(
+pub fn convert_to_ascii_png(
     input_file_name: &str,
     output_file_name: &str,
     rascii_options: &RenderOptions,
-    ascii_image_options: &AsciiImageOptions,
+    pngii_options: &PngiiOptions,
 ) -> Result<(), ()> {
-    let lines = parse_ascii_to_2d_image_vec(input_file_name, rascii_options, ascii_image_options);
+    let lines = parse_ascii_to_2d_image_vec(input_file_name, rascii_options, pngii_options);
     let final_image_writer: Option<AsciiImageWriter> =
-        AsciiImageWriter::from_2d_vec(lines, ascii_image_options);
+        AsciiImageWriter::from_2d_vec(lines, pngii_options);
 
     match final_image_writer {
         Some(writer) => {
@@ -43,5 +49,77 @@ pub fn convert_image_to_ascii_png(
             Ok(())
         }
         None => Err(()),
+    }
+}
+
+/// Converts a GIF into an ASCII GIF.
+/// It does this by first converting the iamge into colored ASCII art,
+/// then renders the ASCII art as an image.
+///
+/// # Params
+/// - `input_file_name` - The input file name.
+/// - `output_file_name` - The output file name.
+/// - `rascii_options` - The `RASCII` render options.
+/// - `pngii_options` - The `PNGII` render options
+///
+/// # Returns
+/// - `Err(())` upon error, `Ok(())` otherwise.
+pub fn convert_to_ascii_gif(
+    input_file_name: &str,
+    output_file_name: &str,
+    rascii_options: &RenderOptions,
+    pngii_options: &PngiiOptions,
+) -> Result<(), ()> {
+    let raw_frames = parse_ascii_to_gif_vec(input_file_name, rascii_options, pngii_options);
+
+    // FIXME: again, we might be breaking the order of all these images
+
+    // create an image writer for each frame
+    let image_writers: Vec<(Option<AsciiImageWriter>, FrameMetadata)> = raw_frames
+        .into_par_iter()
+        .map(|(image_data, frame_metadata)| {
+            (
+                AsciiImageWriter::from_2d_vec(image_data, pngii_options),
+                frame_metadata,
+            )
+        })
+        .collect();
+
+    // DEBUG: now we need to bring the gif together frame-by-frame. Check that this is accurate.
+    let frames: Vec<Frame> = image_writers
+        .into_par_iter()
+        .map(|(image_writer, frame_metadata)| match image_writer {
+            // basically, we want to put the image data and the frame data back into a frame, so we
+            // can then use the image crate to build a new GIF from the new image!
+            Some(image_writer) => Some(Frame::from_parts(
+                image_writer.imagebuf.into(), // converts into its inner held type
+                frame_metadata.left,
+                frame_metadata.top,
+                frame_metadata.delay,
+            )),
+            None => None,
+        })
+        .filter_map(|frame| match frame {
+            Some(frame) => Some(frame),
+            None => None,
+        })
+        .collect();
+
+    let file_writer = BufWriter::new(
+        File::create(output_file_name)
+            .expect(format!("The file {output_file_name} already exists!").as_str()),
+    );
+    let mut gif_encoder = GifEncoder::new(file_writer);
+    // encode the frames
+    match gif_encoder.encode_frames(frames) {
+        Err(err) => {
+            // TODO: what does this print even do?
+            eprintln!(
+                "Could encode frames for image {} ({})",
+                output_file_name, err
+            );
+            Err(())
+        }
+        _ => Ok(()),
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,8 +14,8 @@ use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use crate::image_helper::image_converter::{FrameMetadata, read_as_deconstructed_rendered_gif_vec};
 
 /// Converts an image (such as a PNG or JPEG) into an ASCII PNG.
-/// It does this by first converting the image into colored ASCII art,
-/// then renders the ASCII art as an image.
+/// It does this by first converting the image into colored ASCII text,
+/// then renders the ASCII text as an image.
 ///
 /// # Params
 /// - `input_file_name` - The input file name.
@@ -53,8 +53,8 @@ pub fn convert_to_ascii_png(
 }
 
 /// Converts a GIF into an ASCII GIF.
-/// It does this by first converting the iamge into colored ASCII art,
-/// then renders the ASCII art as an image.
+/// It does this by first converting the image into colored ASCII text,
+/// then renders the ASCII text as an image.
 ///
 /// # Params
 /// - `input_file_name` - The input file name.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,16 @@
 use clap::Parser;
-use pngii::convert_image_to_ascii_png;
-use pngii::image_helper::ascii_image_options::AsciiImageOptions;
+use pngii::convert_to_ascii_gif;
+use pngii::image_helper::ascii_image_options::PngiiOptions;
+use pngii::image_types::IMAGE_STR_TYPES;
+use pngii::{convert_to_ascii_png, image_types::OutputImageType};
 use rascii_art::{
     RenderOptions,
     charsets::{self, from_enum, to_charset_enum},
     convert_string_to_str_vec,
 };
+use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use std::{sync::Arc, time::Instant};
+use threadpool::ThreadPool;
 
 #[derive(Debug, Parser)]
 #[command(author, version, about)]
@@ -75,71 +79,141 @@ fn main() {
         args.width = Some(128);
     }
 
-    let input_name_format = Arc::new(args.input_filename.clone());
-    // panic if we don't find the .png extension at the end
-    let output_name_format = {
-        if !args.output_filename.ends_with(".png") {
-            panic!("The <output_filename> argument does not end with the .png extension")
+    let input_name_format = args.input_filename.clone();
+    let output_name_format = args.output_filename.clone();
+
+    // see what image type we are working with and panic if it's unrecognized
+    let image_type = {
+        // TODO: this block is silly and should be made better with a function possibly implemented
+        // by the OutputImageType enum
+        if args
+            .output_filename
+            .ends_with(IMAGE_STR_TYPES[OutputImageType::Gif as usize])
+        {
+            OutputImageType::Gif
+        } else if args
+            .output_filename
+            .ends_with(IMAGE_STR_TYPES[OutputImageType::Png as usize])
+        {
+            OutputImageType::Png
         } else {
-            Arc::new(args.output_filename.clone())
+            // build the missing values string
+            let missing_values = {
+                let mut missing_values = String::new();
+
+                // build a comma separated list
+                for (i, image_type) in IMAGE_STR_TYPES.iter().enumerate() {
+                    missing_values += image_type;
+                    if i != IMAGE_STR_TYPES.len() - 1 {
+                        missing_values += ", ";
+                    }
+                }
+                missing_values
+            };
+            panic!(
+                "The <output_filename> argument does not end with one of the accepted extensions ({})",
+                missing_values
+            )
         }
     };
 
-    let final_image_index: u32 = args.final_image_index.unwrap_or(1);
+    let rascii_charset = to_charset_enum(&args.charset).unwrap_or(charsets::Charset::Minimal);
 
-    let charset = to_charset_enum(&args.charset).unwrap_or(charsets::Charset::Minimal);
-
-    let rascii_options = Arc::from(RenderOptions {
+    let rascii_options = RenderOptions {
         width: args.width,
         height: args.height,
         colored: true,
         escape_each_colored_char: true,
         invert: args.invert,
-        charset: from_enum(charset),
+        charset: from_enum(rascii_charset),
         char_override: if let Some(char_override) = args.char_override {
             Some(convert_string_to_str_vec(char_override))
         } else {
             None
         },
-    });
+    };
 
-    let ascii_image_options = Arc::from(AsciiImageOptions::new(args.font_size, args.background));
+    let pngii_options = PngiiOptions::new(args.font_size, args.background);
+    match image_type {
+        OutputImageType::Png => {
+            // handle converting a batch of images
+            if let Some(final_image_index) = args.final_image_index {
+                convert_png_batch(
+                    final_image_index,
+                    Arc::from(input_name_format),
+                    Arc::from(output_name_format),
+                    Arc::from(rascii_options),
+                    Arc::from(pngii_options),
+                );
+            } else {
+                match convert_to_ascii_png(
+                    &input_name_format,
+                    &output_name_format,
+                    &rascii_options,
+                    &pngii_options,
+                ) {
+                    Ok(_) => {
+                        println!("Saved PNG {}", output_name_format);
+                    }
+                    Err(_) => {
+                        eprintln!("Could not save PNG {}", output_name_format);
+                    }
+                };
+            }
+        }
+        OutputImageType::Gif => {
+            match convert_to_ascii_gif(
+                &input_name_format,
+                &output_name_format,
+                &rascii_options,
+                &pngii_options,
+            ) {
+                Ok(_) => {
+                    println!("Saved GIF {}", output_name_format);
+                }
+                Err(_) => {
+                    eprintln!("Could not save GIF {}", output_name_format);
+                }
+            }
+        }
+    }
+}
 
-    let pool = threadpool::ThreadPool::new(num_cpus::get());
+fn convert_png_batch(
+    final_image_index: u32,
+    input_name_format: Arc<String>,
+    output_name_format: Arc<String>,
+    rascii_options: Arc<RenderOptions<'static>>,
+    pngii_options: Arc<PngiiOptions>,
+) {
     let starting_time = Instant::now();
-    for i in 1..=final_image_index {
+    // TODO: check what happens if we get a panic in a thread
+    (1..=final_image_index).into_par_iter().for_each(|i| {
         let input_name_format_arc = Arc::clone(&input_name_format);
         let output_name_format_arc = Arc::clone(&output_name_format);
         let rascii_options_arc = Arc::clone(&rascii_options);
-        let ascii_image_options_arc = Arc::clone(&ascii_image_options);
+        let pngii_options_arc = Arc::clone(&pngii_options);
 
-        pool.execute(move || {
-            // convert to ascii before performing the conversion
-            let input_file_name = input_name_format_arc.replace("%d", i.to_string().as_str());
-            let output_file_name = output_name_format_arc.replace("%d", i.to_string().as_str());
-            match convert_image_to_ascii_png(
-                &input_file_name,
-                &output_file_name,
-                &rascii_options_arc,
-                &ascii_image_options_arc,
-            ) {
-                Ok(_) => {
-                    println!("Saved PNG {}", output_file_name);
-                }
-                Err(_) => {
-                    eprintln!("Could not save PNG {}", output_file_name);
-                }
+        // convert to ascii before performing the conversion
+        let input_file_name = input_name_format_arc.replace("%d", i.to_string().as_str());
+        let output_file_name = output_name_format_arc.replace("%d", i.to_string().as_str());
+        match convert_to_ascii_png(
+            &input_file_name,
+            &output_file_name,
+            &rascii_options_arc,
+            &pngii_options_arc,
+        ) {
+            Ok(_) => {
+                println!("Saved PNG {}", output_file_name);
             }
-        });
-    }
+            Err(_) => {
+                // TODO: check this
+                panic!("Could not save PNG {}", output_file_name);
+            }
+        };
+    });
 
-    pool.join();
-    if pool.panic_count() > 0 {
-        eprintln!("---FAIL---");
-        eprintln!("{} thread(s) panicked!", pool.panic_count());
-    } else {
-        println!("---Success!---");
-    }
+    println!("---Success!---");
     println!(
         "Time elapsed: {} seconds / {} milliseconds",
         starting_time.elapsed().as_secs(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
+use pngii::convert_to_ascii_gif;
 use pngii::image_helper::ascii_image_options::PngiiOptions;
 use pngii::image_types::{IMG_TYPES_ARRAY, ImageBatchType};
-use pngii::{convert_to_ascii_gif, image_types};
 use pngii::{convert_to_ascii_png, image_types::OutputImageType};
 use rascii_art::{
     RenderOptions,
@@ -145,11 +145,9 @@ fn main() {
                         &rascii_options,
                         &pngii_options,
                     ) {
-                        Ok(_) => {
-                            println!("Saved PNG {}", output_name_format);
-                        }
+                        Ok(_) => {}
                         Err(_) => {
-                            eprintln!("Could not save PNG {}", output_name_format);
+                            log::error!("Could not save PNG {}", output_name_format);
                         }
                     };
                 }
@@ -158,8 +156,10 @@ fn main() {
         OutputImageType::Gif => {
             match batch_type {
                 ImageBatchType::BatchWithFinalIdx(final_img_idx) => {
+                    // this line was really long, but with a little magic, we can shorten it
                     panic!(
-                        "Cannot convert a batch of GIFs, argument final_img_idx={final_img_idx}"
+                        "Cannot convert a batch of GIFs, argument final_img_idx={final_img_idx}. {}",
+                        "Do not set this argument if intending to convert a GIF."
                     );
                 }
                 ImageBatchType::Single => {
@@ -170,10 +170,10 @@ fn main() {
                         &pngii_options,
                     ) {
                         Ok(_) => {
-                            println!("Saved GIF {}", output_name_format);
+                            log::info!("Saved GIF {}", output_name_format);
                         }
                         Err(_) => {
-                            eprintln!("Could not save GIF {}", output_name_format);
+                            log::error!("Could not save GIF {}", output_name_format);
                         }
                     }
                 }
@@ -207,17 +207,17 @@ fn convert_png_batch(
             &pngii_options_arc,
         ) {
             Ok(_) => {
-                println!("Saved PNG {}", output_file_name);
+                log::info!("Saved PNG {}", output_file_name);
             }
             Err(_) => {
-                // TODO: check this
+                // TODO: does this cause the whole program to crash or just a thread?
                 panic!("Could not save PNG {}", output_file_name);
             }
         };
     });
 
-    println!("---Success!---");
-    println!(
+    log::info!("---Success!---");
+    log::info!(
         "Time elapsed: {} seconds / {} milliseconds",
         starting_time.elapsed().as_secs(),
         starting_time.elapsed().as_millis()

--- a/src/main.rs
+++ b/src/main.rs
@@ -187,6 +187,7 @@ fn main() {
             None
         },
     };
+    log::debug!("RASCII options = {:?}", rascii_options);
 
     // are we doing a batch of images or a single image
     let batch_type = if let Some(final_image_idx) = args.final_image_index {
@@ -197,12 +198,14 @@ fn main() {
 
     // our options for rendering ASCII
     let pngii_options = PngiiOptions::new(args.font_size, args.background);
+    log::debug!("PNGII options = {:?}", pngii_options);
 
     // Now, handle the conversion
     match image_type {
         OutputImageType::Png => {
             match batch_type {
                 ImageBatchType::BatchWithFinalIdx(final_image_idx) => {
+                    log::debug!("Converting batch of PNGs...");
                     // handle converting a batch of images
                     convert_png_batch(
                         final_image_idx,
@@ -213,6 +216,7 @@ fn main() {
                     );
                 }
                 ImageBatchType::Single => {
+                    log::debug!("Converting single PNG...");
                     match convert_to_ascii_png(
                         &input_name_format,
                         &output_name_format,
@@ -237,6 +241,7 @@ fn main() {
                     );
                 }
                 ImageBatchType::Single => {
+                    log::debug!("Converting single GIF");
                     match convert_to_ascii_gif(
                         &input_name_format,
                         &output_name_format,

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,7 +69,6 @@ struct Args {
 }
 
 fn main() {
-    let pool = threadpool::ThreadPool::new(num_cpus::get());
     let mut args = Args::parse();
 
     if args.width.is_none() && args.height.is_none() {
@@ -106,6 +105,7 @@ fn main() {
 
     let ascii_image_options = Arc::from(AsciiImageOptions::new(args.font_size, args.background));
 
+    let pool = threadpool::ThreadPool::new(num_cpus::get());
     let starting_time = Instant::now();
     for i in 1..=final_image_index {
         let input_name_format_arc = Arc::clone(&input_name_format);

--- a/src/main.rs
+++ b/src/main.rs
@@ -256,6 +256,16 @@ fn main() {
     }
 }
 
+/// Renders a batch of PNGs as ASCII and saves to PNG.
+///
+/// * `final_image_index`: The final image index of input PNGs.
+/// * `input_name_format`: The input name format for input PNGs.
+/// * `output_name_format`: The output name format for saved PNGs.
+/// * `rascii_options`: The RASCII options for generating ASCII text.
+/// * `imgii_options`: The imgii options for rendering ASCII as PNG.
+///
+/// # Panics
+/// If a thread fails to convert an image to ASCII, this will cause the program to panic.
 fn convert_png_batch(
     final_image_index: u32,
     input_name_format: Arc<String>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,6 @@ use rascii_art::{
     convert_string_to_str_vec,
 };
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
-use std::sync::Mutex;
 use std::{sync::Arc, time::Instant};
 
 #[derive(Debug, Parser)]


### PR DESCRIPTION
Adds GIF support, enabling the program to render GIFs as ASCII GIFs.
- Use `rayon` for multithreading.
- Update dependencies.
- Clean up the program a bit.
- Add logging.
- Add color output for `clap`.