### PR TITLE
Optimize Image Rendering

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,9 +1,7 @@
 # TODO
 
 - Add brightness setting (0-100) to allow brightening dark images
-- Instead of using 2d vectors throughout the program, flatten them into single vectors
 - Speed up GIF encoding (seems to take up the most time when converting GIFs)
-- Probably should remove the "Internal" error since it's vague.
 
 ## Bugs
 

--- a/src/conversion/converters/generic_converter.rs
+++ b/src/conversion/converters/generic_converter.rs
@@ -1,9 +1,9 @@
-use std::collections::{HashMap, HashSet};
+use std::{collections::HashMap, sync::Arc};
 
 use crate::{
     ImgiiOptions,
     conversion::{image_data::ImageData, render_char_to_png::str_to_png},
-    error::{FontError, ImgiiError, ParseIntError},
+    error::{FontError, ImgiiError, ParseIntError, RenderError},
 };
 
 use super::super::render_char_to_png::{ColoredStr, str_to_transparent_png};
@@ -19,7 +19,7 @@ const FONT_BYTES: &[u8] = include_bytes!("../../../fonts/UbuntuMono.ttf");
 /// Simple struct for holding a 2d image with its width and height.
 #[derive(Clone, Debug)]
 pub(crate) struct Imgii2dImage {
-    pub(crate) image_2d: Vec<ImageData>,
+    pub(crate) image_2d: Vec<Arc<ImageData>>,
     pub(crate) width: usize,
     pub(crate) height: usize,
 }
@@ -43,16 +43,16 @@ pub(crate) fn render_ascii_generic(
     // 2d Vec of images for each character
     let mut image_2d_vec = Vec::new();
 
-    // create this once since it will always be the same
-    let transparent_png = str_to_transparent_png(imgii_options);
-
     // width and height, in characters
     // NOTE: we can know height beforehand but we have to wait until we have parsed a whole line of
     // text to know the width
     let (mut width, height) = (0, ascii_text.lines().count());
 
-    // hold already rendered images so we don't have to render them more than once
-    let mut rendered_images: HashMap<ColoredStr, ImageData> = HashMap::new();
+    // hold already rendered images so we don't have to render them more than once! Rendering is
+    // slow
+    let mut rendered_images: HashMap<ColoredStr, Arc<ImageData>> = HashMap::new();
+    // create transparent image once since it will always be the same
+    let transparent_png = Arc::from(str_to_transparent_png(imgii_options));
 
     // read every line in the file
     for (i, line) in ascii_text.lines().enumerate() {
@@ -96,16 +96,19 @@ pub(crate) fn render_ascii_generic(
                     // check if this image was already rendered before
                     let rendered_img = rendered_images.get(&colored);
                     match rendered_img {
-                        // PERF: what is the performance difference between doing a clone vs Rc
+                        // we have rendered this image before, so clone it
                         Some(rendered_img) => rendered_img.clone(),
                         None => {
-                            let image_data = str_to_png(&colored, &font, imgii_options);
-                            let copied_data = image_data.clone();
-                            let result = rendered_images.insert(colored, image_data);
+                            // we haven't rendered this image before, so render it
+                            let image_data = Arc::from(str_to_png(&colored, &font, imgii_options));
+                            let result = rendered_images.insert(colored, image_data.clone());
                             if result.is_some() {
-                                panic!("this key should not exist already in the hash map");
+                                return Err(RenderError::new(String::from(
+                                    "this image should not exist already in the hash map",
+                                ))
+                                .into());
                             }
-                            copied_data
+                            image_data
                         }
                     }
                 }
@@ -115,26 +118,34 @@ pub(crate) fn render_ascii_generic(
             image_2d_vec.push(generated_png);
         }
 
-        // check that this width is always the same now that we have the width
-        if i != 0 {
-            assert_eq!(
-                width, line_width,
-                "width {} is not equal to the current line width {}",
-                width, line_width
-            );
-        } else {
+        if i == 0 {
+            // get the width of the entire image. This should always be the same
             width = line_width;
-            // now we can reserve the rest of the space for our vec
+            // now we can reserve the rest of the capacity we need for our vec
+            // NOTE: this can panic if the vec is too large
             image_2d_vec.reserve(width * height);
+        } else {
+            // check that this width is always the same now that we have the width
+            if width != line_width {
+                return Err(RenderError::new(format!(
+                    "width {} is not equal to the current line width {}",
+                    width, line_width
+                ))
+                .into());
+            }
         }
     }
 
-    assert!(
-        width * height == image_2d_vec.len(),
-        "expected length of the 2d vector was {} but got {}",
-        width * height,
-        image_2d_vec.len()
-    );
+    // Check that the length of the final vector is what we expect. If not, something has gone
+    // terribly wrong, and we should not continue.
+    if width * height != image_2d_vec.len() {
+        return Err(RenderError::new(format!(
+            "expected length of the 2d vector was {} but got {}",
+            width * height,
+            image_2d_vec.len()
+        ))
+        .into());
+    }
 
     Ok(Imgii2dImage {
         image_2d: image_2d_vec,

--- a/src/conversion/render_char_to_png.rs
+++ b/src/conversion/render_char_to_png.rs
@@ -5,7 +5,9 @@ use imageproc::drawing::draw_text_mut;
 
 /// Represents a colored string to write.
 /// All characters are contiguous and share the same color.
-#[derive(Debug, Clone)]
+/// Is hashable to act as a key for already rendered
+/// images, to prevent rendering them more than once.
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub(crate) struct ColoredStr {
     pub(crate) red: u8,
     pub(crate) blue: u8,
@@ -18,7 +20,7 @@ const BACKGROUND_PIXEL: Rgba<u8> = Rgba([0, 0, 0, u8::MAX]);
 /// Converts string data into a png.
 /// Uses `imageproc` to render text.
 pub(crate) fn str_to_png(
-    data: ColoredStr,
+    data: &ColoredStr,
     font: &FontRef<'_>,
     imgii_options: &ImgiiOptions,
 ) -> ImageData {


### PR DESCRIPTION
Optimizes the image rendering process. The final speed increase from these optimizations seems to range anywhere from 1.5x to 8x+ depending on how large the image is.

This is done by saving rendered character images (since each character image is rendered individually) into a HashMap, so we can only render each character image once.

- Add `RenderError` error type to handle various image rendering errors.